### PR TITLE
Upgrade to dart:js_interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.0.0
+- Upgrade from `package:js` to `dart:js_interop`.
+
 ## v2.14.0
 - **(breaking change)** Support for MSAL.js 2.14.
   - MSAL 2.x has a slightly different API than MSAL 1.x, some notable changes include:
@@ -28,7 +31,7 @@
 - Fix `InteractionRequiredAuthError`s and `ServerError`s not being converted correctly to their exception counterparts.
 
 ## v1.2.2
-- Replace `dart:js` usage with `package:js`. This gets around a `dart2js` issue when compiling a Flutter app for the web and also "modernizes" the codebase a little. 
+- Replace `dart:js` usage with `package:js`. This gets around a `dart2js` issue when compiling a Flutter app for the web and also "modernizes" the codebase a little.
 - Deprecated `MissingMsalJsException`. This is no longer thrown even if msal.js is missing.
 - Added Flutter Web app example.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -37,6 +37,5 @@ linter:
     - throw_in_finally
     - unawaited_futures
     - unnecessary_null_aware_assignments
-    - unsafe_html
     - use_string_buffers
     - use_to_and_as_if_applicable

--- a/lib/msal_js.dart
+++ b/lib/msal_js.dart
@@ -8,13 +8,11 @@
 library msal_js;
 
 import 'dart:async';
+import 'dart:js_interop';
 
-import 'package:js/js.dart';
-import 'package:js/js_util.dart';
-
+import 'src/exceptions.dart';
 import 'src/interop/interop.dart' as interop;
 import 'src/js_proxies/js_proxies.dart';
-import 'src/exceptions.dart';
 
 export 'src/exceptions.dart' hide convertJsError;
 export 'src/interop/interop.dart' show RedirectNavigateCallback;

--- a/lib/src/authentication_result.dart
+++ b/lib/src/authentication_result.dart
@@ -33,13 +33,13 @@ class AuthenticationResult implements EventPayload {
   bool get fromCache => _jsObject.fromCache;
 
   /// Date representing relative expiration of access token.
-  DateTime? get expiresOn => _jsObject.expiresOn;
+  DateTime? get expiresOn => _jsObject.expiresOn?.toDart;
 
   String get tokenType => _jsObject.tokenType;
 
   /// Date representing extended relative expiration of access token in
   /// case of server outage.
-  DateTime? get extExpiresOn => _jsObject.extExpiresOn;
+  DateTime? get extExpiresOn => _jsObject.extExpiresOn?.toDart;
 
   /// Value passed in by user in request.
   String? get state => _jsObject.state;

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -56,7 +56,7 @@ class BrowserAuthOptions {
   ///
   /// Defaults to an empty list.
   set knownAuthorities(List<String>? value) =>
-      _jsObject.knownAuthorities = jsEncode(value);
+      _jsObject.knownAuthorities = jsEncode(value) as JSArray?;
 
   String? get cloudDiscoveryMetadata => _jsObject.cloudDiscoveryMetadata;
 
@@ -117,7 +117,7 @@ class BrowserAuthOptions {
   ///
   /// Defaults to an empty list.
   set clientCapabilities(List<String>? value) =>
-      _jsObject.clientCapabilities = jsEncode(value);
+      _jsObject.clientCapabilities = jsEncode(value) as JSArray?;
 
   String? get protocolMode => _jsObject.protocolMode;
 

--- a/lib/src/interop/account_info.dart
+++ b/lib/src/interop/account_info.dart
@@ -1,13 +1,12 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class AccountInfo {
+extension type AccountInfo._(JSObject _) implements JSObject {
   external String get homeAccountId;
   external String get environment;
   external String get tenantId;
   external String get username;
   external String get localAccountId;
   external String? get name;
-  external dynamic get idTokenClaims;
+  external JSObject? get idTokenClaims;
 }

--- a/lib/src/interop/authentication_result.dart
+++ b/lib/src/interop/authentication_result.dart
@@ -1,20 +1,19 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class AuthenticationResult {
+extension type AuthenticationResult._(JSObject _) implements JSObject {
   external String get authority;
   external String get uniqueId;
   external String get tenantId;
-  external List get scopes;
+  external JSArray get scopes;
   external AccountInfo? get account;
   external String get idToken;
-  external dynamic get idTokenClaims;
+  external JSObject? get idTokenClaims;
   external String get accessToken;
   external bool get fromCache;
-  external DateTime? get expiresOn;
+  external JSDate? get expiresOn;
   external String get tokenType;
-  external DateTime? get extExpiresOn;
+  external JSDate? get extExpiresOn;
   external String? get state;
   external String? get familyId;
   external String? get cloudGraphHostName;

--- a/lib/src/interop/configuration.dart
+++ b/lib/src/interop/configuration.dart
@@ -1,8 +1,9 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class Configuration {
+extension type Configuration._(JSObject _) implements JSObject {
+  factory Configuration() => Configuration._(JSObject());
+
   external BrowserAuthOptions? get auth;
   external set auth(BrowserAuthOptions? auth);
 
@@ -14,16 +15,17 @@ class Configuration {
 }
 
 @JS()
-@anonymous
-class BrowserAuthOptions {
+extension type BrowserAuthOptions._(JSObject _) implements JSObject {
+  factory BrowserAuthOptions() => BrowserAuthOptions._(JSObject());
+
   external String? get clientId;
   external set clientId(String? clientId);
 
   external String? get authority;
   external set authority(String? authority);
 
-  external List? get knownAuthorities;
-  external set knownAuthorities(List? knownAuthorities);
+  external JSArray? get knownAuthorities;
+  external set knownAuthorities(JSArray? knownAuthorities);
 
   external String? get cloudDiscoveryMetadata;
   external set cloudDiscoveryMetadata(String? cloudDiscoveryMetadata);
@@ -40,16 +42,17 @@ class BrowserAuthOptions {
   external bool? get navigateToLoginRequestUrl;
   external set navigateToLoginRequestUrl(bool? navigateToLoginRequestUrl);
 
-  external List? get clientCapabilities;
-  external set clientCapabilities(List? clientCapabilities);
+  external JSArray? get clientCapabilities;
+  external set clientCapabilities(JSArray? clientCapabilities);
 
   external String? get protocolMode;
   external set protocolMode(String? protocolMode);
 }
 
 @JS()
-@anonymous
-class CacheOptions {
+extension type CacheOptions._(JSObject _) implements JSObject {
+  factory CacheOptions() => CacheOptions._(JSObject());
+
   external String? get cacheLocation;
   external set cacheLocation(String? cacheLocation);
 
@@ -61,16 +64,17 @@ class CacheOptions {
 }
 
 @JS()
-@anonymous
-class BrowserSystemOptions {
+extension type BrowserSystemOptions._(JSObject _) implements JSObject {
+  factory BrowserSystemOptions() => BrowserSystemOptions._(JSObject());
+
   external LoggerOptions? get loggerOptions;
   external set loggerOptions(LoggerOptions? loggerOptions);
 
-  external dynamic get networkClient;
-  external set networkClient(dynamic networkClient);
+  external JSObject? get networkClient;
+  external set networkClient(JSObject? networkClient);
 
-  external dynamic get navigationClient;
-  external set navigationClient(dynamic navigationClient);
+  external JSObject? get navigationClient;
+  external set navigationClient(JSObject? navigationClient);
 
   external num? get windowHashTimeout;
   external set windowHashTimeout(num? windowHashTimeout);
@@ -100,10 +104,11 @@ class BrowserSystemOptions {
 }
 
 @JS()
-@anonymous
-class LoggerOptions {
-  external LoggerCallback? get loggerCallback;
-  external set loggerCallback(LoggerCallback? loggerCallback);
+extension type LoggerOptions._(JSObject _) implements JSObject {
+  factory LoggerOptions() => LoggerOptions._(JSObject());
+
+  external JSFunction? get loggerCallback;
+  external set loggerCallback(JSFunction? loggerCallback);
 
   external bool? get piiLoggingEnabled;
   external set piiLoggingEnabled(bool? piiLoggingEnabled);

--- a/lib/src/interop/errors.dart
+++ b/lib/src/interop/errors.dart
@@ -5,8 +5,8 @@ part of 'interop.dart';
 // inheritance information is, apparently, lost when msal.js is compiled to JavaScript.
 // The `name` field however is set to the type name, so we need to just use that.
 
-@JS('AuthError')
-class AuthError extends JsError {
+@JS()
+extension type AuthError._(JSObject _) implements JSObject, JsError {
   external String get errorCode;
   external String get errorMessage;
   external String get subError;

--- a/lib/src/interop/event.dart
+++ b/lib/src/interop/event.dart
@@ -3,11 +3,10 @@ part of 'interop.dart';
 typedef JsEventCallbackFunction = void Function(EventMessage message);
 
 @JS()
-@anonymous
-class EventMessage {
+extension type EventMessage._(JSObject _) implements JSObject {
   external String get eventType;
   external String? get interactionType;
-  external dynamic get payload;
+  external JSObject? get payload;
   external JsError get error;
   external num get timestamp;
 }

--- a/lib/src/interop/interop.dart
+++ b/lib/src/interop/interop.dart
@@ -1,10 +1,12 @@
 @JS('msal')
 library interop;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
+import 'js/date.dart';
 import 'js/error.dart';
 
+export 'js/date.dart';
 export 'js/error.dart';
 export 'js/promise.dart';
 

--- a/lib/src/interop/js/date.dart
+++ b/lib/src/interop/js/date.dart
@@ -1,0 +1,9 @@
+import 'dart:js_interop';
+
+@JS()
+extension type JSDate._(JSObject _) implements JSObject {
+  DateTime get toDart =>
+      DateTime.fromMillisecondsSinceEpoch(getTime(), isUtc: true);
+
+  external int getTime();
+}

--- a/lib/src/interop/js/error.dart
+++ b/lib/src/interop/js/error.dart
@@ -1,11 +1,11 @@
 @JS()
 library error_interop;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 /// A normal JavaScript Error object.
 @JS('Error')
-class JsError {
+extension type JsError._(JSObject _) implements JSObject {
   /// The error type name.
   external String get name;
 

--- a/lib/src/interop/logger.dart
+++ b/lib/src/interop/logger.dart
@@ -4,7 +4,7 @@ typedef LoggerCallback = void Function(
     int level, String message, bool containsPii);
 
 @JS('Logger')
-class Logger {
+extension type Logger._(JSObject _) implements JSObject {
   external Logger(LoggerOptions loggerOptions,
       [String? packageName, String? packageVersion]);
 

--- a/lib/src/interop/navigation_options.dart
+++ b/lib/src/interop/navigation_options.dart
@@ -1,8 +1,7 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class NavigationOptions {
+extension type NavigationOptions._(JSObject _) implements JSObject {
   external num get apiId;
   external num get timeout;
   external bool get noHistory;

--- a/lib/src/interop/network_request_options.dart
+++ b/lib/src/interop/network_request_options.dart
@@ -1,8 +1,7 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class NetworkRequestOptions {
-  external dynamic get headers;
+extension type NetworkRequestOptions._(JSObject _) implements JSObject {
+  external JSObject? get headers;
   external String? get body;
 }

--- a/lib/src/interop/network_response.dart
+++ b/lib/src/interop/network_response.dart
@@ -1,13 +1,14 @@
 part of 'interop.dart';
 
 @JS()
-@anonymous
-class NetworkResponse {
-  external dynamic get headers;
-  external set headers(dynamic headers);
+extension type NetworkResponse._(JSObject _) implements JSObject {
+  factory NetworkResponse() => NetworkResponse._(JSObject());
 
-  external dynamic get body;
-  external set body(dynamic body);
+  external JSObject? get headers;
+  external set headers(JSObject? headers);
+
+  external JSObject? get body;
+  external set body(JSObject? body);
 
   external num get status;
   external set status(num status);

--- a/lib/src/interop/public_client_application.dart
+++ b/lib/src/interop/public_client_application.dart
@@ -1,27 +1,34 @@
 part of 'interop.dart';
 
 @JS('PublicClientApplication')
-class PublicClientApplication {
+extension type PublicClientApplication._(JSObject _) implements JSObject {
   external PublicClientApplication(Configuration configuration);
 
-  external dynamic acquireTokenPopup(PopupRequest request);
-  external dynamic acquireTokenRedirect(RedirectRequest request);
-  external dynamic acquireTokenSilent(SilentRequest request);
-  external String? addEventCallback(JsEventCallbackFunction callback);
+  external JSPromise<AuthenticationResult> acquireTokenPopup(
+      PopupRequest request);
+  external JSPromise<AuthenticationResult> acquireTokenRedirect(
+      RedirectRequest request);
+  external JSPromise<AuthenticationResult> acquireTokenSilent(
+      SilentRequest request);
+  external String? addEventCallback(JSFunction callback);
   external void removeEventCallback(String callbackId);
   external AccountInfo? getAccountByHomeId(String homeAccountId);
   external AccountInfo? getAccountByLocalId(String localId);
   external AccountInfo? getAccountByUsername(String userName);
-  external List getAllAccounts();
-  external dynamic handleRedirectPromise([String? hash]);
-  external dynamic loginPopup([PopupRequest? request]);
-  external dynamic loginRedirect([RedirectRequest? request]);
-  external dynamic logoutRedirect([EndSessionRequest? logoutRequest]);
-  external dynamic logoutPopup([EndSessionPopupRequest? logoutRequest]);
-  external dynamic ssoSilent(SsoSilentRequest request);
+  external JSArray getAllAccounts();
+  external JSPromise<AuthenticationResult> handleRedirectPromise(
+      [String? hash]);
+  external JSPromise<AuthenticationResult> loginPopup([PopupRequest? request]);
+  external JSPromise<AuthenticationResult> loginRedirect(
+      [RedirectRequest? request]);
+  external JSPromise<AuthenticationResult> logoutRedirect(
+      [EndSessionRequest? logoutRequest]);
+  external JSPromise<AuthenticationResult> logoutPopup(
+      [EndSessionPopupRequest? logoutRequest]);
+  external JSPromise<AuthenticationResult> ssoSilent(SsoSilentRequest request);
   external Logger getLogger();
   external void setLogger(Logger logger);
   external void setActiveAccount(AccountInfo? account);
   external AccountInfo? getActiveAccount();
-  external void setNavigationClient(dynamic navigationClient);
+  external void setNavigationClient(JSAny? navigationClient);
 }

--- a/lib/src/interop/request.dart
+++ b/lib/src/interop/request.dart
@@ -7,25 +7,31 @@ part of 'interop.dart';
 typedef RedirectNavigateCallback = bool? Function(String url);
 
 @JS()
-@anonymous
-class SsoSilentRequest extends CommonAuthorizationUrlRequest {
-  external List? get scopes;
-  external set scopes(List? scopes);
+extension type SsoSilentRequest._(JSObject _)
+    implements CommonAuthorizationUrlRequest {
+  factory SsoSilentRequest() => SsoSilentRequest._(JSObject());
+
+  external JSArray? get scopes;
+  external set scopes(JSArray? scopes);
 }
 
 @JS()
-@anonymous
-class EndSessionRequest extends CommonEndSessionRequest {
+extension type EndSessionRequest._(JSObject _)
+    implements CommonEndSessionRequest {
+  factory EndSessionRequest() => EndSessionRequest._(JSObject());
+
   external String? get authority;
   external set authority(String? authority);
 
-  external RedirectNavigateCallback? get onRedirectNavigate;
-  external set onRedirectNavigate(RedirectNavigateCallback? onRedirectNavigate);
+  external JSFunction? get onRedirectNavigate;
+  external set onRedirectNavigate(JSFunction? onRedirectNavigate);
 }
 
 @JS()
-@anonymous
-class EndSessionPopupRequest extends CommonEndSessionRequest {
+extension type EndSessionPopupRequest._(JSObject _)
+    implements CommonEndSessionRequest {
+  factory EndSessionPopupRequest() => EndSessionPopupRequest._(JSObject());
+
   external String? get authority;
   external set authority(String? authority);
 
@@ -34,13 +40,14 @@ class EndSessionPopupRequest extends CommonEndSessionRequest {
 }
 
 @JS()
-@anonymous
-class SilentRequest extends CommonSilentFlowRequest {
+extension type SilentRequest._(JSObject _) implements CommonSilentFlowRequest {
+  factory SilentRequest() => SilentRequest._(JSObject());
+
   external String? get redirectUri;
   external set redirectUri(String? redirectUri);
 
-  external dynamic get extraQueryParameters;
-  external set extraQueryParameters(dynamic extraQueryParameters);
+  external JSObject? get extraQueryParameters;
+  external set extraQueryParameters(JSObject? extraQueryParameters);
 
   external String? get authority;
   external set authority(String? authority);
@@ -56,35 +63,40 @@ class SilentRequest extends CommonSilentFlowRequest {
 }
 
 @JS()
-@anonymous
-class RedirectRequest extends CommonAuthorizationUrlRequest {
-  external List? get scopes;
-  external set scopes(List? scopes);
+extension type RedirectRequest._(JSObject _)
+    implements CommonAuthorizationUrlRequest {
+  factory RedirectRequest() => RedirectRequest._(JSObject());
+
+  external JSArray? get scopes;
+  external set scopes(JSArray? scopes);
 
   external String? get redirectStartPage;
   external set redirectStartPage(String? redirectStartPage);
 
-  external RedirectNavigateCallback? get onRedirectNavigate;
-  external set onRedirectNavigate(RedirectNavigateCallback? onRedirectNavigate);
+  external JSFunction? get onRedirectNavigate;
+  external set onRedirectNavigate(JSFunction? onRedirectNavigate);
 }
 
 @JS()
-@anonymous
-class PopupRequest extends CommonAuthorizationUrlRequest {
-  external List? get scopes;
-  external set scopes(List? scopes);
+extension type PopupRequest._(JSObject _)
+    implements CommonAuthorizationUrlRequest {
+  factory PopupRequest() => PopupRequest._(JSObject());
+
+  external JSArray? get scopes;
+  external set scopes(JSArray? scopes);
 }
 
 @JS()
-@anonymous
-class CommonSilentFlowRequest {
-  external dynamic get tokenQueryParameters;
-  external set tokenQueryParameters(dynamic tokenQueryParameters);
+extension type CommonSilentFlowRequest._(JSObject _) implements JSObject {
+  factory CommonSilentFlowRequest() => CommonSilentFlowRequest._(JSObject());
+
+  external JSObject? get tokenQueryParameters;
+  external set tokenQueryParameters(JSObject? tokenQueryParameters);
 
   // BaseAuthRequest
 
-  external List? get scopes;
-  external set scopes(List? scopes);
+  external JSArray? get scopes;
+  external set scopes(JSArray? scopes);
 
   external String? get authenticationScheme;
   external set authenticationScheme(String? correlationId);
@@ -103,8 +115,10 @@ class CommonSilentFlowRequest {
 }
 
 @JS()
-@anonymous
-class CommonAuthorizationUrlRequest {
+extension type CommonAuthorizationUrlRequest._(JSObject _) implements JSObject {
+  factory CommonAuthorizationUrlRequest() =>
+      CommonAuthorizationUrlRequest._(JSObject());
+
   external String? get redirectUri;
   external set redirectUri(String? redirectUri);
 
@@ -114,14 +128,14 @@ class CommonAuthorizationUrlRequest {
   external String? get domainHint;
   external set domainHint(String? domainHint);
 
-  external dynamic get extraQueryParameters;
-  external set extraQueryParameters(dynamic extraQueryParameters);
+  external JSAny? get extraQueryParameters;
+  external set extraQueryParameters(JSAny? extraQueryParameters);
 
-  external dynamic get tokenQueryParameters;
-  external set tokenQueryParameters(dynamic tokenQueryParameters);
+  external JSAny? get tokenQueryParameters;
+  external set tokenQueryParameters(JSAny? tokenQueryParameters);
 
-  external List? get extraScopesToConsent;
-  external set extraScopesToConsent(List? extraScopesToConsent);
+  external JSArray? get extraScopesToConsent;
+  external set extraScopesToConsent(JSArray? extraScopesToConsent);
 
   external String? get loginHint;
   external set loginHint(String? loginHint);
@@ -163,8 +177,9 @@ class CommonAuthorizationUrlRequest {
 }
 
 @JS()
-@anonymous
-class CommonEndSessionRequest {
+extension type CommonEndSessionRequest._(JSObject _) implements JSObject {
+  factory CommonEndSessionRequest() => CommonEndSessionRequest._(JSObject());
+
   external String? get correlationId;
   external set correlationId(String? correlationId);
 

--- a/lib/src/js_proxies/interop/array.dart
+++ b/lib/src/js_proxies/interop/array.dart
@@ -1,7 +1,6 @@
-@JS()
 library array;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('Array')
-class Array {}
+extension type JSArray._(JSObject _) implements JSObject {}

--- a/lib/src/js_proxies/interop/object.dart
+++ b/lib/src/js_proxies/interop/object.dart
@@ -1,9 +1,8 @@
-@JS()
 library object;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('Object')
-class Object {
-  external static List keys(dynamic object);
+extension type Object._(JSObject _) implements JSObject {
+  external static JSArray<JSString> keys(JSObject object);
 }

--- a/lib/src/js_proxies/interop/reflect.dart
+++ b/lib/src/js_proxies/interop/reflect.dart
@@ -1,9 +1,8 @@
-@JS()
 library reflect;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('Reflect')
-class Reflect {
-  external static void deleteProperty(dynamic object, dynamic property);
+extension type Reflect._(JSObject _) implements JSObject {
+  external static void deleteProperty(JSObject object, JSAny property);
 }

--- a/lib/src/js_proxies/js_array_list_proxy.dart
+++ b/lib/src/js_proxies/js_array_list_proxy.dart
@@ -6,7 +6,7 @@ part of 'js_proxies.dart';
 /// respectively and vice versa without copying the underlying JS value (e.g.
 /// modifying the "proxied" JS Array/Object will be reflected in JS and vice versa).
 class JsArrayListProxy<E> with ListMixin<E> {
-  final dynamic _jsArray;
+  final JSArray _jsArray;
 
   JsArrayListProxy(this._jsArray);
 
@@ -17,7 +17,7 @@ class JsArrayListProxy<E> with ListMixin<E> {
   set length(int length) => _jsArray.length = length;
 
   @override
-  E operator [](int index) => jsDecode(_jsArray[index]);
+  E operator [](int index) => jsDecode(_jsArray[index]) as E;
 
   @override
   void operator []=(int index, E value) => _jsArray[index] = jsEncode(value);

--- a/lib/src/js_proxies/js_object_map_proxy.dart
+++ b/lib/src/js_proxies/js_object_map_proxy.dart
@@ -6,36 +6,37 @@ part of 'js_proxies.dart';
 /// respectively and vice versa without copying the underlying JS value (e.g.
 /// modifying the "proxied" JS Array/Object will be reflected in JS and vice versa).
 class JsObjectMapProxy<V> with MapMixin<String, V> {
-  final dynamic _jsObject;
+  final JSObject _jsObject;
 
   JsObjectMapProxy(this._jsObject);
 
   @override
-  Iterable<String> get keys => interop.Object.keys(_jsObject).cast<String>();
+  Iterable<String> get keys =>
+      interop.Object.keys(_jsObject).toDart.map((e) => e.toDart);
 
   @override
   V? operator [](Object? key) {
     ArgumentError.checkNotNull(key, 'key');
 
-    return jsDecode(getProperty(_jsObject, key!));
+    return jsDecode(_jsObject.getProperty(key.jsify()!)) as V?;
   }
 
   @override
   void operator []=(String key, V value) {
-    setProperty(_jsObject, key, jsEncode(value));
+    _jsObject.setProperty(key.toJS, jsEncode(value));
   }
 
   @override
   void clear() {
     for (final key in keys) {
-      interop.Reflect.deleteProperty(_jsObject, key);
+      interop.Reflect.deleteProperty(_jsObject, key.toJS);
     }
   }
 
   @override
   V? remove(Object? key) {
     final value = this[key];
-    interop.Reflect.deleteProperty(_jsObject, key);
+    interop.Reflect.deleteProperty(_jsObject, key.jsify()!);
 
     return value;
   }

--- a/lib/src/js_proxies/js_proxies.dart
+++ b/lib/src/js_proxies/js_proxies.dart
@@ -1,8 +1,8 @@
 import 'dart:collection';
 
-import 'package:js/js_util.dart';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
-import 'interop/array.dart' as interop;
 import 'interop/object.dart' as interop;
 import 'interop/reflect.dart' as interop;
 
@@ -10,25 +10,25 @@ part 'js_array_list_proxy.dart';
 part 'js_object_map_proxy.dart';
 
 /// Decodes the given [value] as a typed Dart [List].
-List<E>? jsDecodeList<E>(dynamic value) {
+List<E>? jsDecodeList<E>(JSAny? value) {
   if (value == null) {
     return null;
   } else {
-    assert(value is interop.Array ||
-        (value is List && value is! JsArrayListProxy));
+    assert(
+        value.isA<JSArray>() || (value is List && value is! JsArrayListProxy));
 
-    return JsArrayListProxy<E>(value);
+    return JsArrayListProxy<E>(value as JSArray);
   }
 }
 
 /// Decodes the given [value] as a typed Dart [Map].
-Map<String, V>? jsDecodeMap<V>(dynamic value) {
+Map<String, V>? jsDecodeMap<V>(JSAny? value) {
   if (value == null) {
     return null;
   } else {
-    assert(value is interop.Object);
+    assert(value.isA<JSObject>());
 
-    return JsObjectMapProxy<V>(value);
+    return JsObjectMapProxy<V>(value as JSObject);
   }
 }
 
@@ -36,17 +36,17 @@ Map<String, V>? jsDecodeMap<V>(dynamic value) {
 ///
 /// Accepts standard Dart primitives, [JsArrayListProxy], [JsObjectMapProxy],
 /// [Map], and [Iterable] values. Other values will be returned unchanged.
-dynamic jsEncode(dynamic value) {
+dynamic jsEncode(Object? value) {
   if (value != null) {
     if (value is JsArrayListProxy) {
       // Get proxied JS Array
-      value = value._jsArray;
+      return value._jsArray;
     } else if (value is JsObjectMapProxy) {
       // Get proxied JS Object
-      value = value._jsObject;
+      return value._jsObject;
     } else if (value is Map || value is Iterable) {
       // JSify Dart Maps and Iterables
-      value = jsify(value);
+      return value.jsify();
     }
   }
 
@@ -56,15 +56,14 @@ dynamic jsEncode(dynamic value) {
 /// Decodes the given [value] into a native Dart type.
 ///
 /// Accepts JS `Array`s and JS `Object`s. Other values will be returned unchanged.
-dynamic jsDecode(dynamic value) {
+dynamic jsDecode(JSAny? value) {
   if (value != null) {
-    if (value is interop.Array ||
-        (value is List && value is! JsArrayListProxy)) {
+    if (value.isA<JSArray>() || (value is List && value is! JsArrayListProxy)) {
       // Proxy JS Array
-      value = JsArrayListProxy(value);
+      return JsArrayListProxy(value as JSArray);
     } else if (value is interop.Object) {
       // Proxy JS Object
-      value = JsObjectMapProxy(value);
+      return JsObjectMapProxy(value);
     }
   }
 

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -43,7 +43,7 @@ class LoggerOptions {
         value(_getLogLevel(level), message, containsPii);
       }
 
-      _jsObject.loggerCallback = allowInterop(jsCallback);
+      _jsObject.loggerCallback = jsCallback.toJS;
     }
   }
 

--- a/lib/src/navigation_client.dart
+++ b/lib/src/navigation_client.dart
@@ -14,16 +14,14 @@ abstract class INavigationClient {
 
 /// Jsify's the navigation [client] so MSAL can call its methods.
 dynamic _allowNavigationClientInterop(INavigationClient client) {
-  return jsify(<String, dynamic>{
-    'navigateInternal':
-        allowInterop((String url, interop.NavigationOptions options) {
+  return <String, dynamic>{
+    'navigateInternal': (String url, interop.NavigationOptions options) {
       return _futureToPromise(client.navigateInternal(
           url, NavigationOptions._fromJsObject(options)));
-    }),
-    'navigateExternal':
-        allowInterop((String url, interop.NavigationOptions options) {
+    }.toJS,
+    'navigateExternal': (String url, interop.NavigationOptions options) {
       return _futureToPromise(client.navigateExternal(
           url, NavigationOptions._fromJsObject(options)));
-    }),
-  });
+    }.toJS,
+  }.jsify();
 }

--- a/lib/src/network_module.dart
+++ b/lib/src/network_module.dart
@@ -17,8 +17,8 @@ abstract class INetworkModule {
 
 /// Jsify's the network [module] so MSAL can call its methods.
 dynamic _allowNetworkModuleInterop(INetworkModule module) {
-  return jsify(<String, dynamic>{
-    'sendGetRequestAsync': allowInterop((String url,
+  return <String, dynamic>{
+    'sendGetRequestAsync': (String url,
         [interop.NetworkRequestOptions? options, num? cancellationToken]) {
       return _futureToPromise(
           module.sendGetRequestAsync(
@@ -28,8 +28,8 @@ dynamic _allowNetworkModuleInterop(INetworkModule module) {
                   : NetworkRequestOptions._fromJsOjbect(options),
               cancellationToken),
           resolveHelper: (NetworkResponse value) => value._jsObject);
-    }),
-    'sendPostRequestAsync': allowInterop((String url,
+    }.toJS,
+    'sendPostRequestAsync': (String url,
         [interop.NetworkRequestOptions? options, num? cancellationToken]) {
       return _futureToPromise(
           module.sendPostRequestAsync(
@@ -38,6 +38,6 @@ dynamic _allowNetworkModuleInterop(INetworkModule module) {
                   ? null
                   : NetworkRequestOptions._fromJsOjbect(options)),
           resolveHelper: (NetworkResponse value) => value._jsObject);
-    })
-  });
+    }.toJS,
+  }.jsify();
 }

--- a/lib/src/network_response.dart
+++ b/lib/src/network_response.dart
@@ -15,7 +15,7 @@ class NetworkResponse {
       required dynamic body,
       required num status})
       : _jsObject = interop.NetworkResponse()
-          ..headers = jsEncode(headers)
-          ..body = jsEncode(body)
+          ..headers = jsEncode(headers) as JSObject?
+          ..body = jsEncode(body) as JSObject?
           ..status = status;
 }

--- a/lib/src/public_client_application.dart
+++ b/lib/src/public_client_application.dart
@@ -63,7 +63,7 @@ class PublicClientApplication {
   ///
   /// Throws an [AuthException] on failure.
   Future<void> acquireTokenRedirect(RedirectRequest request) async {
-    await _convertMsalPromise<void>(
+    await _convertMsalPromise(
         _callJsMethod(() => _jsObject.acquireTokenRedirect(request._jsObject)));
   }
 
@@ -85,9 +85,9 @@ class PublicClientApplication {
   /// Returns a callback ID that can be later used to unregister the function.
   String? addEventCallback(EventCallbackFunction callback) {
     return _callJsMethod(() {
-      return _jsObject.addEventCallback(allowInterop((message) {
+      return _jsObject.addEventCallback((interop.EventMessage message) {
         callback(EventMessage._fromJsObject(message));
-      }));
+      }.toJS);
     });
   }
 
@@ -140,6 +140,7 @@ class PublicClientApplication {
   List<AccountInfo> getAllAccounts() {
     return _callJsMethod(() => _jsObject
         .getAllAccounts()
+        .toDart
         .cast<interop.AccountInfo>()
         .map((jsAccount) => AccountInfo._fromJsObject(jsAccount))
         .toList());
@@ -189,7 +190,7 @@ class PublicClientApplication {
   ///
   /// Throws an [AuthException] on failure.
   Future<void> loginRedirect([RedirectRequest? request]) async {
-    await _convertMsalPromise<void>(
+    await _convertMsalPromise(
         _callJsMethod(() => _jsObject.loginRedirect(request?._jsObject)));
   }
 
@@ -200,7 +201,7 @@ class PublicClientApplication {
   ///
   /// Throws an [AuthException] on failure.
   Future<void> logoutRedirect([EndSessionRequest? logoutRequest]) async {
-    await _convertMsalPromise<void>(_callJsMethod(
+    await _convertMsalPromise(_callJsMethod(
         () => _jsObject.logoutRedirect(logoutRequest?._jsObject)));
   }
 
@@ -209,7 +210,7 @@ class PublicClientApplication {
   ///
   /// Throws an [AuthException] on failure.
   Future<void> logoutPopup([EndSessionPopupRequest? logoutRequest]) async {
-    await _convertMsalPromise<void>(
+    await _convertMsalPromise(
         _callJsMethod(() => _jsObject.logoutPopup(logoutRequest?._jsObject)));
   }
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -6,7 +6,8 @@ class SsoSilentRequest extends CommonAuthorizationUrlRequest
 
   /// List of scopes the application is requesting access to
   /// (optional for ssoSilent calls).
-  set scopes(List<String>? value) => _jsObject.scopes = jsEncode(value);
+  set scopes(List<String>? value) =>
+      _jsObject.scopes = jsEncode(value) as JSArray?;
 
   @override
   final interop.SsoSilentRequest _jsObject;
@@ -25,13 +26,17 @@ class EndSessionRequest extends CommonEndSessionRequest
   set authority(String? value) => _jsObject.authority = value;
 
   interop.RedirectNavigateCallback? get onRedirectNavigate =>
-      _jsObject.onRedirectNavigate;
+      _jsObject.onRedirectNavigate == null
+          ? null
+          : (String url) => (_jsObject.onRedirectNavigate!
+                  .callAsFunction(url.toJS) as JSBoolean)
+              .toDart;
 
   /// Callback that will be passed the url that MSAL will navigate to.
   ///
   /// Returning false in the callback will stop navigation.
   set onRedirectNavigate(interop.RedirectNavigateCallback? value) =>
-      _jsObject.onRedirectNavigate = value == null ? null : allowInterop(value);
+      _jsObject.onRedirectNavigate = value?.toJS;
 
   @override
   final interop.EndSessionRequest _jsObject;
@@ -82,7 +87,7 @@ class SilentRequest extends CommonSilentFlowRequest implements EventPayload {
   ///
   /// Only used when renewing the refresh token.
   set extraQueryParameters(Map<String, String>? value) =>
-      _jsObject.extraQueryParameters = jsEncode(value);
+      _jsObject.extraQueryParameters = jsEncode(value) as JSObject?;
 
   String? get authority => _jsObject.authority;
 
@@ -121,7 +126,8 @@ class RedirectRequest extends CommonAuthorizationUrlRequest
   List<String>? get scopes => jsDecodeList<String>(_jsObject.scopes);
 
   /// List of scopes the application is requesting access to.
-  set scopes(List<String>? value) => _jsObject.scopes = jsEncode(value);
+  set scopes(List<String>? value) =>
+      _jsObject.scopes = jsEncode(value) as JSArray?;
 
   String? get redirectStartPage => _jsObject.redirectStartPage;
 
@@ -135,13 +141,17 @@ class RedirectRequest extends CommonAuthorizationUrlRequest
   set redirectStartPage(String? value) => _jsObject.redirectStartPage = value;
 
   interop.RedirectNavigateCallback? get onRedirectNavigate =>
-      _jsObject.onRedirectNavigate;
+      _jsObject.onRedirectNavigate == null
+          ? null
+          : (String url) => (_jsObject.onRedirectNavigate!
+                  .callAsFunction(url.toJS) as JSBoolean)
+              .toDart;
 
   /// Callback that will be passed the url that MSAL will navigate to.
   ///
   /// Returning `false` in the callback will stop navigation.
   set onRedirectNavigate(interop.RedirectNavigateCallback? value) =>
-      _jsObject.onRedirectNavigate = value == null ? null : allowInterop(value);
+      _jsObject.onRedirectNavigate = value?.toJS;
 
   @override
   final interop.RedirectRequest _jsObject;
@@ -157,7 +167,8 @@ class PopupRequest extends CommonAuthorizationUrlRequest
   List<String>? get scopes => jsDecodeList<String>(_jsObject.scopes);
 
   /// List of scopes the application is requesting access to.
-  set scopes(List<String>? value) => _jsObject.scopes = jsEncode(value);
+  set scopes(List<String>? value) =>
+      _jsObject.scopes = jsEncode(value) as JSArray?;
 
   @override
   final interop.PopupRequest _jsObject;
@@ -175,14 +186,15 @@ abstract class CommonSilentFlowRequest {
   /// String to string map of custom query parameters added to the
   /// `/token` call.
   set tokenQueryParameters(Map<String, String>? value) =>
-      _jsObject.tokenQueryParameters = jsEncode(value);
+      _jsObject.tokenQueryParameters = jsEncode(value) as JSObject?;
 
   // BaseAuthRequest
 
   List<String>? get scopes => jsDecodeList<String>(_jsObject.scopes);
 
   /// List of scopes the application is requesting access to.
-  set scopes(List<String>? value) => _jsObject.scopes = jsEncode(value);
+  set scopes(List<String>? value) =>
+      _jsObject.scopes = jsEncode(value) as JSArray?;
 
   String? get authenticationScheme => _jsObject.authenticationScheme;
 
@@ -256,7 +268,7 @@ abstract class CommonAuthorizationUrlRequest {
   /// String to string map of custom query parameters added to the
   /// `/authorize` call.
   set extraQueryParameters(Map<String, String>? value) =>
-      _jsObject.extraQueryParameters = jsEncode(value);
+      _jsObject.extraQueryParameters = jsEncode(value) as JSObject?;
 
   Map<String, String>? get tokenQueryParameters =>
       jsDecodeMap<String>(_jsObject.tokenQueryParameters);
@@ -264,14 +276,14 @@ abstract class CommonAuthorizationUrlRequest {
   /// String to string map of custom query parameters added to the
   /// `/token` call.
   set tokenQueryParameters(Map<String, String>? value) =>
-      _jsObject.tokenQueryParameters = jsEncode(value);
+      _jsObject.tokenQueryParameters = jsEncode(value) as JSObject?;
 
   List<String>? get extraScopesToConsent =>
       jsDecodeList<String>(_jsObject.extraScopesToConsent);
 
   /// Scopes for a different resource when the user needs consent upfront.
   set extraScopesToConsent(List<String>? value) =>
-      _jsObject.extraScopesToConsent = jsEncode(value);
+      _jsObject.extraScopesToConsent = jsEncode(value) as JSArray?;
 
   String? get loginHint => _jsObject.loginHint;
 

--- a/lib/src/utils/error_utils.dart
+++ b/lib/src/utils/error_utils.dart
@@ -13,9 +13,9 @@ T _callJsMethod<T>(T Function() function) {
 /// Converts and awaits the given MSAL JS [promise].
 ///
 /// Automatically converts MSAL errors to exceptions that are thrown from it.
-Future<T> _convertMsalPromise<T>(dynamic promise) async {
+Future<T> _convertMsalPromise<T extends JSAny?>(JSPromise<T> promise) async {
   try {
-    return await promiseToFuture<T>(promise);
+    return await promise.toDart;
   } on interop.JsError catch (ex) {
     throw convertJsError(ex);
   }

--- a/lib/src/utils/promise_utils.dart
+++ b/lib/src/utils/promise_utils.dart
@@ -3,15 +3,14 @@ part of '../../msal_js.dart';
 typedef _FutureToPromiseValueHelper<T> = dynamic Function(T value);
 
 /// Converts the given Dart [future] to a JavaScript promise.
-interop.Promise _futureToPromise<T>(Future<T> future,
+JSPromise<JSAny?> _futureToPromise<T>(Future<T> future,
     {_FutureToPromiseValueHelper<T>? resolveHelper,
-    _FutureToPromiseValueHelper<dynamic>? rejectHelper}) {
-  return interop.Promise(allowInterop((resolve, reject) {
+    _FutureToPromiseValueHelper<T>? rejectHelper}) {
+  return JSPromise((JSFunction resolve, JSFunction reject) {
     future.then(
-        (value) => resolve(resolveHelper == null
-            ? jsEncode(value as dynamic)
-            : resolveHelper(value)),
-        onError: (error) => reject(
-            rejectHelper == null ? jsEncode(error) : rejectHelper(error)));
-  }));
+        (value) => resolve.callAsFunction(
+            resolveHelper == null ? value.jsify() : resolveHelper(value)),
+        onError: (error) => reject.callAsFunction(
+            rejectHelper == null ? error.jsify() : rejectHelper(error)));
+  }.toJS);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,12 @@
 name: msal_js
 description: "A Dart wrapper for the 'Microsoft Authentication Library for JavaScript (MSAL.js)'."
-version: 2.14.0
+version: 3.0.0
 homepage: https://github.com/Francessco121/msal-js-dart
 repository: https://github.com/Francessco121/msal-js-dart
 issue_tracker: https://github.com/Francessco121/msal-js-dart/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-
-dependencies:
-  js: ^0.6.3
+  sdk: ">=3.6.0 <4.0.0"
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
Modernizes this package upgrading JS interop to new static interop (i.e. `package:js` -> `dart:js_interop`)

Fixes https://github.com/Francessco121/msal-js-dart/issues/43